### PR TITLE
Fix file stat condition if the stat object doesn't exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) 
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+### Fixed
+- Fix file stat condition if the stat object doesn't exist
+
 ## [1.0.0] - 2017-02-03
 ### Added
 - Created the role to provision CA certificates to system-wide nssdb

--- a/tasks/configure-system.yml
+++ b/tasks/configure-system.yml
@@ -16,7 +16,7 @@
     path: '{{ nssdb_system_path }}'
     state: directory
   register: nssdb_folder_created
-  when: nssdb_stat is defined and nssdb_stat.stat.exists == false
+  when: nssdb_stat is defined and nssdb_stat.stat is defined and nssdb_stat.stat.exists == false
 
 - name: Initialize db in system-wide {{ nssdb_system_path }}
   command: certutil -N -d sql:{{ nssdb_system_path }} --empty-password

--- a/tasks/configure-users.yml
+++ b/tasks/configure-users.yml
@@ -22,7 +22,7 @@
     path: '/home/{{ nssdb_user }}/.pki/nssdb'
     state: directory
   register: nssdb_folder_created_user
-  when: nssdb_stat_user is defined and nssdb_stat_user.stat.exists == false
+  when: nssdb_stat_user is defined and nssdb_stat_user.stat is defined and nssdb_stat_user.stat.exists == false
 
 - name: Initialize db in users ~{{ nssdb_user }}/.pki/nssdb
   become: true


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | -
| Related issues/PRs | -
| License | MIT

#### What's in this PR?

Fix the check on nssdb_stat.stat condition if the stat object doesn't exist instead of simply being false :disappointed: 