### PR TITLE
:bug: fix ansible deprication

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,4 +4,4 @@ nssdb_certificates: []
 
 # certutils package state; use 'installed' to make sure it's installed, or 'latest' if
 # you want to upgrade or switch versions using a new repo.
-certutils_package_state: installed
+certutils_package_state: present

--- a/tasks/configure-system.yml
+++ b/tasks/configure-system.yml
@@ -20,7 +20,7 @@
 
 - name: Initialize db in system-wide {{ nssdb_system_path }}
   command: certutil -N -d sql:{{ nssdb_system_path }} --empty-password
-  when: nssdb_folder_created|changed
+  when: nssdb_folder_created.changed
 
 - name: Install certificates to system-wide {{ nssdb_system_path }}
   command: >


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | yes
| Fixed tickets | fixes #issuenum
| Related issues/PRs | #issuenum
| License | MIT

#### What's in this PR?

Fixing deprecations with ansible 2.9.4

#### Why?

Deprecations

#### BC Breaks/Deprecations

FAILED! => {"changed": false, "msg": "value of state must be one of: absent, build-dep, fixed, latest, present, got: installed"}

And:

d %} True {% else %} False {% endif %}\n\nThe error appears to be in '/etc/ansible/roles/pixelart.nssdb/tasks/configure-system.yml': line 21, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n- name: Initialize db in system-wide {{ nssdb_system_path }}\n  ^ here\nWe could be wrong, but this one looks like it might be an issue with\nmissing quotes. Always quote template expression brackets when th

#### To Do

- [ ] Create documentation
